### PR TITLE
fix: transport configuration to include fallback for polling in WebSocket connection.

### DIFF
--- a/src/socket-socketio.js
+++ b/src/socket-socketio.js
@@ -1,8 +1,10 @@
 import io from 'socket.io-client';
 
 export default function(socketUrl, customData, path) {
-  const options = path ? { path } : {};
-  options.transports = ['websocket'];
+  const options = {
+    path,
+    transports: ['polling', 'websocket']
+  };
 
   const socket = io(socketUrl, options);
 


### PR DESCRIPTION
### Changes
`fix`: transport configuration to include fallback for polling in WebSocket connection.

- Updated the `options` object to include both `websocket` and `polling` as transport options.
- Ensured `polling` is used as a fallback when `websocket` is unavailable.
- Simplified path assignment by directly including it in the options object.

REF: https://socket.io/docs/v3/how-it-works/#Transports