### PR TITLE
fix: add customdata to initialize widget session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rasa-webchat",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -335,7 +335,8 @@ class Widget extends Component {
       initialized,
       connectOn,
       tooltipPayload,
-      tooltipDelay
+      tooltipDelay,
+      customData
     } = this.props;
     if (!socket.isInitialized()) {
       socket.createSocket();
@@ -351,7 +352,7 @@ class Widget extends Component {
       // Request a session from server
       socket.on('connect', () => {
         const localId = this.getSessionId();
-        socket.emit('session_request', { session_id: localId });
+        socket.emit('session_request', { session_id: localId, custom_data: customData });
       });
 
       // When session_confirm is received from the server:


### PR DESCRIPTION
## Changes
`fix`: add `customData`  variable to the initialization of a widget session.

Updated the emit method of the socket connection of the widget so that it sends `custom_data` as well as `sender_id`.
