### PR TITLE
fix: Added Conditional for Comparing Local and Remote Session IDs

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -372,7 +372,7 @@ class Widget extends Component {
         start a new session.
         */
         const localId = this.getSessionId();
-        const { userId } = customData || {};
+        const userId = customData?.userId;
         if (!userId && (localId !== remoteId)) {
           // storage.clear();
           // Store the received session_id to storage

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -372,7 +372,8 @@ class Widget extends Component {
         start a new session.
         */
         const localId = this.getSessionId();
-        if (localId !== remoteId) {
+        const { userId } = customData || {};
+        if (!userId && (localId !== remoteId)) {
           // storage.clear();
           // Store the received session_id to storage
 


### PR DESCRIPTION
Jira Ticket: [CUS-77](https://tagshelf.atlassian.net/browse/CUS-77)

## Changes

- Introduced a new constant `userId` extracted from `customData`.

- Updated the conditional check to only compare `localId` and `remoteId` when `userId` is not present.

- This prevents the widget from incorrectly starting a new session, preserving the existing conversation context.

[CUS-77]: https://tagshelf.atlassian.net/browse/CUS-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ